### PR TITLE
Bump bosh-provisioner

### DIFF
--- a/lib/vagrant-bosh/version.rb
+++ b/lib/vagrant-bosh/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module VagrantBosh
-    VERSION = "0.0.8"
+    VERSION = "0.0.9"
   end
 end


### PR DESCRIPTION
This should fix: https://github.com/cppforlife/bosh-provisioner/issues/10, which was not a bosh-provisioner issue but an vagrant-bosh issue